### PR TITLE
feat: add Redis support to the application

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-amqp")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.flywaydb:flyway-core:${property("flywayCoreVersion")}")
     implementation("org.flywaydb:flyway-database-postgresql:${property("flywayCoreVersion")}")
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/codesumn/sboot/order/processor/application/config/RedisConfig.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package codesumn.sboot.order.processor.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,13 @@ spring.datasource.url=${POSTGRES_URL:jdbc:postgresql://localhost:5432/order_db}
 spring.datasource.username=${POSTGRES_USER:order_user}
 spring.datasource.password=${POSTGRES_PASSWORD:order_pass}
 
+# Redis Configuration
+spring.data.redis.host=${REDIS_HOST:localhost}
+spring.data.redis.port=${REDIS_PORT:6379}
+spring.data.redis.password=${REDIS_PASS:}
+spring.data.redis.timeout=6000
+spring.data.redis.database=${REDIS_DATABASE:0}
+
 # Data JPA
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.open-in-view=false
@@ -22,7 +29,7 @@ spring.flyway.locations=classpath:db/migration
 spring.flyway.baseline-on-migrate=true
 
 # RabbitMQ Configuration
-spring.rabbitmq.host=${RABBITMQ_HOST:rabbitmq}
+spring.rabbitmq.host=${RABBITMQ_HOST:localhost}
 spring.rabbitmq.port=${RABBITMQ_PORT:5672}
 spring.rabbitmq.username=${RABBITMQ_USER:admin}
 spring.rabbitmq.password=${RABBITMQ_PASS:secret}


### PR DESCRIPTION
- Introduce `RedisConfig` class to configure RedisTemplate with custom serializers.
- Add `spring-boot-starter-data-redis` dependency to `build.gradle.kts` for Redis integration.
- Update `application.properties` with Redis configuration properties (host, port, password, database, and timeout).
- Modify RabbitMQ host default value for better local development consistency.