### PR TITLE
refactor: use DTOs for messaging and improve RabbitMQ config

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
@@ -108,7 +108,9 @@ public class OrderServiceAdapter implements OrderServicePort {
 
         OrderModel savedOrder = orderPersistencePort.saveOrder(order);
 
-        orderMessagingPort.sendOrder(order);
+        OrderRecordDto savedOrderRecord = convertToOrderRecordDto(savedOrder);
+
+        orderMessagingPort.sendOrder(savedOrderRecord);
 
         return ResponseDto.create(convertToOrderRecordDto(savedOrder));
     }
@@ -159,6 +161,7 @@ public class OrderServiceAdapter implements OrderServicePort {
     private List<OrderItemRecordDto> convertOrderItems(List<OrderItemModel> items) {
         return items.stream()
                 .map(item -> new OrderItemRecordDto(
+                        item.getId(),
                         item.getProductName(),
                         item.getQuantity(),
                         item.getPrice()

--- a/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
@@ -2,6 +2,7 @@ package codesumn.sboot.order.processor.application.config;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,7 +12,13 @@ public class RabbitMQConfig {
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
         return rabbitTemplate;
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
     }
 }

--- a/src/main/java/codesumn/sboot/order/processor/application/dtos/records/order/OrderItemRecordDto.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/dtos/records/order/OrderItemRecordDto.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 
 public record OrderItemRecordDto(
+        @NotBlank UUID id,
         @NotBlank String productName,
         @NotNull @Min(1) Integer quantity,
         @NotNull @Min(0) BigDecimal unitPrice

--- a/src/main/java/codesumn/sboot/order/processor/domain/outbound/OrderMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/processor/domain/outbound/OrderMessagingPort.java
@@ -1,7 +1,7 @@
 package codesumn.sboot.order.processor.domain.outbound;
 
-import codesumn.sboot.order.processor.domain.models.OrderModel;
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
 
 public interface OrderMessagingPort {
-    void sendOrder(OrderModel order);
+    void sendOrder(OrderRecordDto order);
 }

--- a/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderMessagingAdapter.java
@@ -1,6 +1,6 @@
 package codesumn.sboot.order.processor.infrastructure.adapters.messaging;
 
-import codesumn.sboot.order.processor.domain.models.OrderModel;
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
 import codesumn.sboot.order.processor.domain.outbound.OrderMessagingPort;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,7 +24,7 @@ public class OrderMessagingAdapter implements OrderMessagingPort {
     }
 
     @Override
-    public void sendOrder(OrderModel order) {
+    public void sendOrder(OrderRecordDto order) {
         rabbitTemplate.convertAndSend(exchange, routingKey, order);
     }
 }


### PR DESCRIPTION
- Updated `OrderMessagingPort` to use `OrderRecordDto` instead of `OrderModel` for better separation of concerns.
- Modified `OrderServiceAdapter` to convert `OrderModel` to `OrderRecordDto` before sending.
- Added `UUID id` field to `OrderItemRecordDto` for enhanced traceability.
- Enhanced `RabbitMQConfig` by introducing `Jackson2JsonMessageConverter` for JSON message conversion.
- Ensured all messaging-related logic is consistent with the new DTO structure.