### PR TITLE
refactor: rename service port interfaces and update logic

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
@@ -8,7 +8,7 @@ import codesumn.sboot.order.processor.application.dtos.records.pagination.Pagina
 import codesumn.sboot.order.processor.application.dtos.records.pagination.PaginationResponseDto;
 import codesumn.sboot.order.processor.application.dtos.records.response.ResponseDto;
 import codesumn.sboot.order.processor.application.mappers.OrderMapper;
-import codesumn.sboot.order.processor.domain.inbound.OrderServicePort;
+import codesumn.sboot.order.processor.domain.inbound.OrderServiceAdapterPort;
 import codesumn.sboot.order.processor.domain.models.OrderItemModel;
 import codesumn.sboot.order.processor.domain.models.OrderModel;
 import codesumn.sboot.order.processor.domain.outbound.OrderMessagingPort;
@@ -33,7 +33,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
-public class OrderServiceAdapter implements OrderServicePort {
+public class OrderServiceAdapter implements OrderServiceAdapterPort {
     private final OrderPersistencePort orderPersistencePort;
     private final OrderMessagingPort orderMessagingPort;
     private final SortParser sortParser;

--- a/src/main/java/codesumn/sboot/order/processor/application/controllers/OrderController.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/controllers/OrderController.java
@@ -5,7 +5,7 @@ import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecord
 import codesumn.sboot.order.processor.application.dtos.records.pagination.PaginationResponseDto;
 import codesumn.sboot.order.processor.application.dtos.records.response.ResponseDto;
 import codesumn.sboot.order.processor.application.param.FilterCriteriaParamDto;
-import codesumn.sboot.order.processor.domain.inbound.OrderServicePort;
+import codesumn.sboot.order.processor.domain.inbound.OrderServiceAdapterPort;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -20,10 +20,10 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/orders")
 public class OrderController {
-    private final OrderServicePort orderServicePort;
+    private final OrderServiceAdapterPort orderServicePort;
 
     @Autowired
-    public OrderController(OrderServicePort orderServicePort) {
+    public OrderController(OrderServiceAdapterPort orderServicePort) {
         this.orderServicePort = orderServicePort;
     }
 

--- a/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderResponseMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderResponseMessagingPort.java
@@ -1,5 +1,7 @@
 package codesumn.sboot.order.processor.domain.inbound;
 
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
+
 public interface OrderResponseMessagingPort {
-    void consumeOrderResponse(String message);
+    void consumeOrderResponse(OrderRecordDto message);
 }

--- a/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderServiceAdapterPort.java
+++ b/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderServiceAdapterPort.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
-public interface OrderServicePort {
+public interface OrderServiceAdapterPort {
     PaginationResponseDto<List<OrderRecordDto>> findAll(
             int page,
             int pageSize,

--- a/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
@@ -1,20 +1,33 @@
 package codesumn.sboot.order.processor.infrastructure.adapters.messaging;
 
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderInputRecordDto;
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
 import codesumn.sboot.order.processor.domain.inbound.OrderResponseMessagingPort;
+import codesumn.sboot.order.processor.domain.inbound.OrderServiceAdapterPort;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class OrderResponseMessagingAdapter implements OrderResponseMessagingPort {
 
-    @Value("${spring.rabbitmq.processor.response.queue}")
-    private String responseQueue;
+    private final OrderServiceAdapterPort orderServiceAdapterPort;
+
+    @Autowired
+    public OrderResponseMessagingAdapter(OrderServiceAdapterPort orderServiceAdapterPort) {
+        this.orderServiceAdapterPort = orderServiceAdapterPort;
+    }
 
     @Override
     @RabbitListener(queues = "${spring.rabbitmq.processor.response.queue}")
-    public void consumeOrderResponse(String message) {
-        System.out.println("📥 Mensagem recebida da fila '" + responseQueue + "': " + message);
-        // TODO: Implementar lógica de processamento aqui...
+    public void consumeOrderResponse(OrderRecordDto order) {
+        OrderInputRecordDto orderInputRecordDto = new OrderInputRecordDto(
+                order.customerName(),
+                order.totalPrice(),
+                order.orderStatus().name(),
+                order.items()
+        );
+
+        orderServiceAdapterPort.updateOrder(order.id(), orderInputRecordDto);
     }
 }

--- a/src/main/java/codesumn/sboot/order/processor/shared/enums/OrderStatusEnum.java
+++ b/src/main/java/codesumn/sboot/order/processor/shared/enums/OrderStatusEnum.java
@@ -9,7 +9,7 @@ public enum OrderStatusEnum {
 
     PENDING("pending"),
     PROCESSING("processing"),
-    COMPLETED("completed"),
+    PROCESSED("processed"),
     CANCELED("canceled");
 
     private final String value;


### PR DESCRIPTION
- Renamed `OrderServicePort` interface to `OrderServiceAdapterPort` for better clarity and alignment with naming conventions.
- Updated references across `OrderController`, `OrderServiceAdapter`, and `OrderResponseMessagingAdapter` to adapt to the new interface name.
- Modified `consumeOrderResponse` in `OrderResponseMessagingPort` to accept `OrderRecordDto` instead of `String`, enabling type-safe order processing.
- Updated `OrderStatusEnum` to rename `COMPLETED` status to `PROCESSED` for improved consistency in status naming.