### PR TITLE
Add message compression and confirmation to RabbitMQ

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
@@ -1,5 +1,7 @@
 package codesumn.sboot.order.processor.application.config;
 
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -9,6 +11,12 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
 @Configuration
 public class RabbitMQConfig {
 
@@ -17,6 +25,21 @@ public class RabbitMQConfig {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
+
+        rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
+            if (!ack) {
+                System.err.println("Erro no envio da mensagem: " + cause);
+            }
+        });
+
+        rabbitTemplate.setBeforePublishPostProcessors(message -> {
+            byte[] compressedBody = compress(message.getBody());
+            message.getMessageProperties().setContentEncoding("gzip");
+            message.getMessageProperties().setContentLength(compressedBody.length);
+            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
+            return new Message(compressedBody, message.getMessageProperties());
+        });
+
         return rabbitTemplate;
     }
 
@@ -32,9 +55,45 @@ public class RabbitMQConfig {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(jackson2JsonMessageConverter());
+
+        factory.setAfterReceivePostProcessors(message -> {
+            if ("gzip".equalsIgnoreCase(message.getMessageProperties().getContentEncoding())) {
+                byte[] decompressedBody = decompress(message.getBody());
+                return new Message(decompressedBody, message.getMessageProperties());
+            }
+            return message;
+        });
+
         factory.setConcurrentConsumers(1);
         factory.setMaxConcurrentConsumers(1);
         factory.setPrefetchCount(1);
+
         return factory;
+    }
+
+    private static byte[] compress(byte[] data) {
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+             GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
+            gzip.write(data);
+            gzip.close();
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Erro ao comprimir mensagem", e);
+        }
+    }
+
+    private static byte[] decompress(byte[] compressedData) {
+        try (ByteArrayInputStream bis = new ByteArrayInputStream(compressedData);
+             GZIPInputStream gzip = new GZIPInputStream(bis);
+             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = gzip.read(buffer)) != -1) {
+                bos.write(buffer, 0, len);
+            }
+            return bos.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Erro ao descomprimir mensagem", e);
+        }
     }
 }


### PR DESCRIPTION
- Implement message compression using GZIP in `RabbitTemplate` with `setBeforePublishPostProcessors`.
- Add decompression logic in `SimpleRabbitListenerContainerFactory` with `setAfterReceivePostProcessors`.
- Configure message confirmation callback to log errors when message delivery fails.
- Enhance message persistence by setting `MessageDeliveryMode.PERSISTENT`.