### PR TITLE
Switch to byte array messaging with ObjectMapper

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/config/RabbitMQConfig.java
@@ -1,21 +1,12 @@
 package codesumn.sboot.order.processor.application.config;
 
-import org.springframework.amqp.core.Message;
-import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
-import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.GZIPOutputStream;
 
 @Configuration
 public class RabbitMQConfig {
@@ -23,7 +14,6 @@ public class RabbitMQConfig {
     @Bean
     public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
         RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
-        rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
         rabbitTemplate.setMandatory(true);
 
         rabbitTemplate.setConfirmCallback((correlationData, ack, cause) -> {
@@ -32,20 +22,7 @@ public class RabbitMQConfig {
             }
         });
 
-        rabbitTemplate.setBeforePublishPostProcessors(message -> {
-            byte[] compressedBody = compress(message.getBody());
-            message.getMessageProperties().setContentEncoding("gzip");
-            message.getMessageProperties().setContentLength(compressedBody.length);
-            message.getMessageProperties().setDeliveryMode(MessageDeliveryMode.PERSISTENT);
-            return new Message(compressedBody, message.getMessageProperties());
-        });
-
         return rabbitTemplate;
-    }
-
-    @Bean
-    public Jackson2JsonMessageConverter jackson2JsonMessageConverter() {
-        return new Jackson2JsonMessageConverter();
     }
 
     @Bean
@@ -54,46 +31,10 @@ public class RabbitMQConfig {
     ) {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
-        factory.setMessageConverter(jackson2JsonMessageConverter());
-
-        factory.setAfterReceivePostProcessors(message -> {
-            if ("gzip".equalsIgnoreCase(message.getMessageProperties().getContentEncoding())) {
-                byte[] decompressedBody = decompress(message.getBody());
-                return new Message(decompressedBody, message.getMessageProperties());
-            }
-            return message;
-        });
-
         factory.setConcurrentConsumers(1);
         factory.setMaxConcurrentConsumers(1);
         factory.setPrefetchCount(1);
 
         return factory;
-    }
-
-    private static byte[] compress(byte[] data) {
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
-             GZIPOutputStream gzip = new GZIPOutputStream(bos)) {
-            gzip.write(data);
-            gzip.close();
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Erro ao comprimir mensagem", e);
-        }
-    }
-
-    private static byte[] decompress(byte[] compressedData) {
-        try (ByteArrayInputStream bis = new ByteArrayInputStream(compressedData);
-             GZIPInputStream gzip = new GZIPInputStream(bis);
-             ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            byte[] buffer = new byte[1024];
-            int len;
-            while ((len = gzip.read(buffer)) != -1) {
-                bos.write(buffer, 0, len);
-            }
-            return bos.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Erro ao descomprimir mensagem", e);
-        }
     }
 }

--- a/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderResponseMessagingPort.java
+++ b/src/main/java/codesumn/sboot/order/processor/domain/inbound/OrderResponseMessagingPort.java
@@ -1,7 +1,5 @@
 package codesumn.sboot.order.processor.domain.inbound;
 
-import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
-
 public interface OrderResponseMessagingPort {
-    void consumeOrderResponse(OrderRecordDto message);
+    void consumeOrderResponse(byte[] message);
 }

--- a/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderMessagingAdapter.java
@@ -2,6 +2,8 @@ package codesumn.sboot.order.processor.infrastructure.adapters.messaging;
 
 import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
 import codesumn.sboot.order.processor.domain.outbound.OrderMessagingPort;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -12,19 +14,28 @@ public class OrderMessagingAdapter implements OrderMessagingPort {
     private final RabbitTemplate rabbitTemplate;
     private final String exchange;
     private final String routingKey;
+    private final ObjectMapper objectMapper;
 
     public OrderMessagingAdapter(
             RabbitTemplate rabbitTemplate,
             @Value("${spring.rabbitmq.order.exchange}") String exchange,
-            @Value("${spring.rabbitmq.order.routing.key}") String routingKey
+            @Value("${spring.rabbitmq.order.routing.key}") String routingKey,
+            ObjectMapper objectMapper
     ) {
         this.rabbitTemplate = rabbitTemplate;
         this.exchange = exchange;
         this.routingKey = routingKey;
+        this.objectMapper = objectMapper;
     }
 
     @Override
     public void sendOrder(OrderRecordDto order) {
-        rabbitTemplate.convertAndSend(exchange, routingKey, order);
+        try {
+            byte[] messageBytes = objectMapper.writeValueAsBytes(order);
+            Message message = new Message(messageBytes);
+            rabbitTemplate.send(exchange, routingKey, message);
+        } catch (Exception e) {
+            throw new RuntimeException("Erro ao serializar mensagem", e);
+        }
     }
 }


### PR DESCRIPTION
- Updated `OrderResponseMessagingAdapter` to deserialize messages using `ObjectMapper` from byte arrays instead of directly handling `OrderRecordDto` objects.
- Modified `OrderMessagingAdapter` to serialize `OrderRecordDto` objects to byte arrays using `ObjectMapper` before sending messages.
- Removed Jackson message converter and custom compression functionality from `RabbitMQConfig` to simplify configuration and reduce overhead.
- Adjusted `OrderResponseMessagingPort` interface to handle byte array payloads in `consumeOrderResponse`.