### PR TITLE
Implement domain event for order creation

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/events/OrderCreatedEvent.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/events/OrderCreatedEvent.java
@@ -1,0 +1,6 @@
+package codesumn.sboot.order.processor.application.events;
+
+import codesumn.sboot.order.processor.application.dtos.records.order.OrderRecordDto;
+
+public record OrderCreatedEvent(OrderRecordDto order) {
+}

--- a/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderEventListener.java
+++ b/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderEventListener.java
@@ -1,0 +1,21 @@
+package codesumn.sboot.order.processor.infrastructure.adapters.messaging;
+
+import codesumn.sboot.order.processor.application.events.OrderCreatedEvent;
+import codesumn.sboot.order.processor.domain.outbound.OrderMessagingPort;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+public class OrderEventListener {
+
+    private final OrderMessagingPort orderMessagingPort;
+
+    public OrderEventListener(OrderMessagingPort orderMessagingPort) {
+        this.orderMessagingPort = orderMessagingPort;
+    }
+
+    @TransactionalEventListener
+    public void handleOrderCreated(OrderCreatedEvent event) {
+        orderMessagingPort.sendOrder(event.order());
+    }
+}


### PR DESCRIPTION
- Add `OrderCreatedEvent` to represent the order creation event.
- Create `OrderEventListener` to handle `OrderCreatedEvent` and send messages via `OrderMessagingPort`.
- Modify `OrderServiceAdapter` to use `ApplicationEventPublisher` for publishing the `OrderCreatedEvent`.
- Replace the direct messaging call in `OrderServiceAdapter` with event publishing to enhance decoupling of services.