### PR TITLE
Add Swagger configuration for API documentation

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/config/SwaggerConfig.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package codesumn.sboot.order.processor.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Order Processor")
+                        .version("1.0.0")
+                        .description("Order Processor API"));
+    }
+}


### PR DESCRIPTION
- Introduce `SwaggerConfig` class to configure OpenAPI.
- Enable API documentation with title, version, and description for the "Order Processor" application.