### PR TITLE
Remove unnecessary annotations and improve readability

### DIFF
--- a/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/adapters/inbound/OrderServiceAdapter.java
@@ -19,7 +19,6 @@ import codesumn.sboot.order.processor.shared.exceptions.errors.ResourceNotFoundE
 import codesumn.sboot.order.processor.shared.parsers.SortParser;
 import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotNull;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -40,7 +39,6 @@ public class OrderServiceAdapter implements OrderServiceAdapterPort {
     private final SortParser sortParser;
     private final ApplicationEventPublisher eventPublisher;
 
-    @Autowired
     public OrderServiceAdapter(
             OrderPersistencePort orderPersistencePort,
             SortParser sortParser,

--- a/src/main/java/codesumn/sboot/order/processor/application/controllers/OrderController.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/controllers/OrderController.java
@@ -7,7 +7,6 @@ import codesumn.sboot.order.processor.application.dtos.records.response.Response
 import codesumn.sboot.order.processor.application.param.FilterCriteriaParamDto;
 import codesumn.sboot.order.processor.domain.inbound.OrderServiceAdapterPort;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springdoc.core.annotations.ParameterObject;
@@ -22,7 +21,6 @@ import java.util.UUID;
 public class OrderController {
     private final OrderServiceAdapterPort orderServicePort;
 
-    @Autowired
     public OrderController(OrderServiceAdapterPort orderServicePort) {
         this.orderServicePort = orderServicePort;
     }

--- a/src/main/java/codesumn/sboot/order/processor/application/validators/order/DateRangeValidator.java
+++ b/src/main/java/codesumn/sboot/order/processor/application/validators/order/DateRangeValidator.java
@@ -6,7 +6,6 @@ import jakarta.validation.ConstraintValidatorContext;
 
 public class DateRangeValidator implements ConstraintValidator<ValidDateRange, FilterCriteriaParamDto> {
 
-    @Override
     public boolean isValid(FilterCriteriaParamDto value, ConstraintValidatorContext context) {
         boolean startDatePresent = value.getStartDate() != null;
         boolean endDatePresent = value.getEndDate() != null;

--- a/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
+++ b/src/main/java/codesumn/sboot/order/processor/infrastructure/adapters/messaging/OrderResponseMessagingAdapter.java
@@ -6,7 +6,6 @@ import codesumn.sboot.order.processor.domain.inbound.OrderResponseMessagingPort;
 import codesumn.sboot.order.processor.domain.inbound.OrderServiceAdapterPort;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,7 +14,6 @@ public class OrderResponseMessagingAdapter implements OrderResponseMessagingPort
     private final OrderServiceAdapterPort orderServiceAdapterPort;
     private final ObjectMapper objectMapper;
 
-    @Autowired
     public OrderResponseMessagingAdapter(OrderServiceAdapterPort orderServiceAdapterPort, ObjectMapper objectMapper) {
         this.orderServiceAdapterPort = orderServiceAdapterPort;
         this.objectMapper = objectMapper;

--- a/src/main/java/codesumn/sboot/order/processor/shared/exceptions/errors/DuplicateOrderException.java
+++ b/src/main/java/codesumn/sboot/order/processor/shared/exceptions/errors/DuplicateOrderException.java
@@ -2,7 +2,7 @@ package codesumn.sboot.order.processor.shared.exceptions.errors;
 
 public class DuplicateOrderException extends RuntimeException {
 
-    private static final String DEFAULT_MESSAGE = "Pedido duplicado! Já existe um pedido com os mesmos itens.";
+    private static final String DEFAULT_MESSAGE = "Duplicate order! An order with the same items already exists.";
 
     public DuplicateOrderException() {
         super(DEFAULT_MESSAGE);


### PR DESCRIPTION
- Remove `@Autowired` annotations from constructors as they are redundant with constructor-based injection in Spring.
- Update default exception message in `DuplicateOrderException` for consistency and clarity in English.
- Clean up `@Override` usage in `DateRangeValidator` to reduce noise in the code.
- Ensure the codebase adheres to a cleaner and more streamlined structure.