### PR TITLE
Add workflow for Docker image build and push

### DIFF
--- a/.github/workflows /docker-image-ci.yml
+++ b/.github/workflows /docker-image-ci.yml
@@ -1,0 +1,29 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: thoggs/sboot-order-processor:latest


### PR DESCRIPTION
- Introduce a GitHub Actions workflow (`docker-image-ci.yml`) for automating Docker image build and push.
- Trigger workflow on `main` branch pushes and pull requests.
- Include steps to check out the repository, log in to Docker Hub, and build/push the image using `docker/build-push-action`.
- Tag the built image as `thoggs/sboot-order-processor:latest`.