### PR TITLE
Add descriptive name to Docker CI workflow job

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build and Push
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- Add a `name` field with the value "Build and Push" to the `build` job in the Docker CI workflow.