### PR TITLE
Remove CI trigger for pushes to main branch

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,8 +1,6 @@
 name: Docker Image CI
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
- Eliminate the `push` event trigger to streamline workflow.
- Retain the `pull_request` trigger for main branch validation.