### PR TITLE
Trigger Docker CI pipeline on push to main

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:


### PR DESCRIPTION
- Update workflow configuration to trigger on `push` instead of `pull_request`.
- Ensure builds are initiated for all pushes to the `main` branch.