### PR TITLE
Add multi-platform support for Docker image builds

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -26,3 +26,4 @@ jobs:
           file: Dockerfile
           push: true
           tags: thoggs/sboot-order-processor:latest
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
- Include `linux/amd64` and `linux/arm64` in the build platforms.
- Ensure compatibility with multiple architectures during CI builds.