### PR TITLE
Add QEMU and Buildx setup for multi-platform builds

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
- Introduce `docker/setup-qemu-action@v3` to enable QEMU setup.
- Add `docker/setup-buildx-action@v3` for Docker Buildx configuration.
- Ensure multi-platform Docker image builds with enhanced compatibility.