### PR TITLE
Update Flyway core version to 11.3.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-extra["flywayCoreVersion"] = "11.3.0"
+extra["flywayCoreVersion"] = "11.3.1"
 extra["springdocVersion"] = "2.8.4"
 
 plugins {


### PR DESCRIPTION
- Bump Flyway core dependency from 11.3.0 to 11.3.1 in `build.gradle.kts`.
- Ensure access to latest patches and bug fixes.