### PR TITLE
Increase build discard limit in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
 	options {
 		disableConcurrentBuilds()
-        buildDiscarder(logRotator(numToKeepStr: '4'))
+        buildDiscarder(logRotator(numToKeepStr: '5'))
 	}
 
 	triggers {


### PR DESCRIPTION
- Update `logRotator` to retain 5 builds instead of 4.
- Helps maintain a longer build history for debugging and reference.