### PR TITLE
Replace Docker CI workflow with Jenkins pipeline

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -1,35 +1,35 @@
-name: Docker Image CI
-
-on:
-  push:
-    branches: [ "main" ]
-
-jobs:
-  build:
-    name: Build and Push
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          tags: thoggs/sboot-order-processor:latest
-          platforms: linux/amd64,linux/arm64
+#name: Docker Image CI
+#
+#on:
+#  push:
+#    branches: [ "main" ]
+#
+#jobs:
+#  build:
+#    name: Build and Push
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v4
+#
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
+#
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v3
+#
+#      - name: Log in to Docker Hub
+#        uses: docker/login-action@v3
+#        with:
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKER_PASSWORD }}
+#
+#      - name: Build and push Docker image
+#        uses: docker/build-push-action@v6
+#        with:
+#          context: .
+#          file: Dockerfile
+#          push: true
+#          tags: thoggs/sboot-order-processor:latest
+#          platforms: linux/amd64,linux/arm64

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,56 +1,67 @@
 pipeline {
 	agent any
 
-	options {
+    options {
 		disableConcurrentBuilds()
         buildDiscarder(logRotator(numToKeepStr: '5'))
-	}
+        skipDefaultCheckout(true)
+    }
 
-	triggers {
+    triggers {
 		githubPush()
     }
 
     environment {
-		DOCKER_IMAGE = 'thoggs/sboot-order-processor:latest'
+		DOCKER_IMAGE = 'thoggs/sboot-order-dispatcher:latest'
     }
 
     stages {
 		stage('Checkout') {
 			steps {
-				git branch: 'main', url: 'https://github.com/thoggs/sboot-order-processor.git'
+				git branch: 'main', url: 'https://github.com/thoggs/sboot-order-dispatcher.git'
             }
         }
 
-        stage('Build Docker Image') {
+        stage('Set up QEMU') {
 			steps {
-				sh 'docker build -t $DOCKER_IMAGE .'
+				sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes'
+            }
+        }
+
+        stage('Set up Docker Buildx') {
+			steps {
+				sh 'docker buildx create --use --name mybuilder || true'
+                sh 'docker buildx inspect --bootstrap'
             }
         }
 
         stage('Login to Docker Hub') {
 			steps {
 				withCredentials([
-					usernamePassword(
-						credentialsId: 'docker-hub-credentials',
+                    usernamePassword(
+                        credentialsId: 'docker-hub-credentials',
                         usernameVariable: 'DOCKER_USERNAME',
                         passwordVariable: 'DOCKER_PASSWORD'
-					)
-				]) {
+                    )
+                ]) {
 					sh 'echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin'
                 }
             }
         }
 
-        stage('Push to Docker Hub') {
+        stage('Build and Push Multi-Arch Docker Image') {
 			steps {
-				sh 'docker push $DOCKER_IMAGE'
+				sh '''
+                    docker buildx build --platform linux/amd64,linux/arm64 \
+                        -t $DOCKER_IMAGE \
+                        --push .
+                '''
             }
         }
 
         stage('Cleanup') {
 			steps {
-				sh 'docker rmi -f $DOCKER_IMAGE || true'
-                sh 'docker system prune -f --volumes || true'
+				sh 'docker system prune -f --volumes || true'
             }
         }
     }


### PR DESCRIPTION
- Comment out the existing GitHub Actions workflow for Docker image CI in `.github/workflows/docker-image-ci.yml`.
- Update the Jenkinsfile to replace single-arch Docker builds with multi-arch builds using Docker Buildx.
- Modify repository and Docker image references from `sboot-order-processor` to `sboot-order-dispatcher`.
- Add set-up steps for QEMU emulation and multi-arch Docker Buildx in Jenkins pipeline.
- Improve the cleanup stage by removing unnecessary image deletion logic.