### PR TITLE
fix: adjust Docker cache and environment variable formatting

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -34,4 +34,4 @@ jobs:
           tags: thoggs/sboot-order-processor:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,force=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN gradle clean build -x test
 
 FROM oraclelinux:9
 
-ENV LANG en_US.UTF-8
+ENV LANG=en_US.UTF-8
 ARG JAVA_VERSION=21
 ENV JAVA_HOME=/usr/java/jdk-$JAVA_VERSION
 ENV PATH=$JAVA_HOME/bin:$PATH


### PR DESCRIPTION
- Add `force=true` to `cache-to` in Docker CI workflow for consistency and potential build optimization.
- Correct environment variable formatting in Dockerfile by adding `=` for `LANG` to align with best practices.