### PR TITLE
Optimize Docker Buildx caching and add cache pruning

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Prune Buildx Cache
+        run: |
+          docker builder prune -a -f
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -33,5 +37,5 @@ jobs:
           push: true
           tags: thoggs/sboot-order-processor:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=${{ github.sha }}
-          cache-to: type=gha,mode=max,scope=${{ github.sha }}
+          cache-from: type=gha,scope=${{ github.repository }}
+          cache-to: type=gha,mode=max,scope=${{ github.repository }}


### PR DESCRIPTION
- Add a Buildx cache pruning step to clean up unused cache and reduce storage usage.
- Update `cache-from` and `cache-to` scopes to use `${{ github.repository }}` for better cache sharing across workflows.