### PR TITLE
Update cache scope in Docker image workflow

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -37,5 +37,5 @@ jobs:
           push: true
           tags: thoggs/sboot-order-processor:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=${{ github.repository }}
-          cache-to: type=gha,mode=max,scope=${{ github.repository }}
+          cache-from: type=gha,scope=${{ github.run_id }}
+          cache-to: type=gha,mode=max,scope=${{ github.run_id }}


### PR DESCRIPTION
- Change `cache-from` scope from `github.repository` to `github.run_id` for more granular caching.
- Change `cache-to` scope from `github.repository` to `github.run_id` to align with `cache-from`.
- Ensure better caching behavior by using unique run identifiers.