### PR TITLE
Add --no-cache build argument to Docker CI workflow

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -39,3 +39,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ github.run_id }}
           cache-to: type=gha,mode=max,scope=${{ github.run_id }}
+          build-args: --no-cache


### PR DESCRIPTION
- Include `--no-cache` in the `build-args` to ensure fresh Docker image builds.
- Prevent potential issues caused by cached layers during CI builds.