### PR TITLE
Remove unused cache settings from Docker build step

### DIFF
--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -37,6 +37,3 @@ jobs:
           push: true
           tags: thoggs/sboot-order-processor:latest
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=${{ github.run_id }}
-          cache-to: type=gha,mode=max,scope=${{ github.run_id }}
-          build-args: --no-cache


### PR DESCRIPTION
- Deleted `cache-from` and `cache-to` parameters to streamline the workflow.
- Removed redundant `--no-cache` build argument for cleaner configuration.
- Enhances maintainability by simplifying the Docker image CI workflow.