### PR TITLE
Credentials for AWS ECR login in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,10 +40,18 @@ pipeline {
 
         stage('Login to AWS ECR Public') {
 			steps {
-				sh '''
-                    aws ecr-public get-login-password --region $AWS_REGION \
-                    | docker login --username AWS --password-stdin public.ecr.aws
-                '''
+				withCredentials([
+                    usernamePassword(
+                        credentialsId: 'aws-credentials',
+                        usernameVariable: 'AWS_ACCESS_KEY_ID',
+                        passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+                    )
+                ]) {
+					sh '''
+                        aws ecr-public get-login-password --region $AWS_REGION \
+                        | docker login --username AWS --password-stdin public.ecr.aws
+                    '''
+                }
             }
         }
 


### PR DESCRIPTION
- wrapped AWS ECR login command in withCredentials block.
- used aws-credentials for providing access keys securely.