### PR TITLE
Remove githubPush trigger from Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,6 @@ pipeline {
         skipDefaultCheckout(true)
     }
 
-    triggers {
-		githubPush()
-    }
-
     environment {
 		DOCKER_IMAGE = 'public.ecr.aws/n1a9j0r1/sboot-order-processor'
         AWS_REGION = 'us-east-1'


### PR DESCRIPTION
- deleted `githubPush` trigger from Jenkinsfile.
- cleaned up unused trigger configuration.