### PR TITLE
Use containers for Jenkins pipeline steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,82 @@
-pipeline {
+//pipeline {
+//
+//	agent {
+//		label 'ec2-java17-agent'
+//    }
+//
+//    options {
+//		buildDiscarder(logRotator(numToKeepStr: '5'))
+//        skipDefaultCheckout(true)
+//    }
+//
+//    environment {
+//		DOCKER_IMAGE = 'public.ecr.aws/n1a9j0r1/sboot-order-processor'
+//        AWS_REGION = 'us-east-1'
+//    }
+//
+//    stages {
+//
+//		stage('Checkout') {
+//			steps {
+//				git branch: 'main', url: 'https://github.com/thoggs/sboot-order-processor.git'
+//            }
+//        }
+//
+//        stage('Set up QEMU') {
+//			steps {
+//				sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || true'
+//    		}
+//		}
+//
+//        stage('Set up Docker Buildx') {
+//			steps {
+//				sh 'docker buildx create --use --name mybuilder || true'
+//                sh 'docker buildx inspect --bootstrap'
+//            }
+//        }
+//
+//        stage('Login to AWS ECR Public') {
+//			steps {
+//				withCredentials([
+//                    usernamePassword(
+//                        credentialsId: 'aws-username-password',
+//                        usernameVariable: 'AWS_ACCESS_KEY_ID',
+//                        passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+//                    )
+//                ]) {
+//					sh '''
+//                        aws ecr-public get-login-password --region $AWS_REGION \
+//                        | docker login --username AWS --password-stdin public.ecr.aws
+//                    '''
+//                }
+//            }
+//        }
+//
+//        stage('SonarQube Analysis') {
+//			steps {
+//				withSonarQubeEnv('sonarqube-server') {
+//					sh 'sonar-scanner -Dsonar.projectKey=sboot-order-processor -Dsonar.sources=.'
+//                }
+//            }
+//        }
+//
+//        stage('Build Multi-Arch') {
+//			steps {
+//				sh '''
+//                    docker buildx build \
+//						--platform linux/amd64,linux/arm64 \
+//						-t $DOCKER_IMAGE:latest \
+//						--push .
+//                '''
+//            }
+//        }
+//
+//    }
+//}
 
+pipeline {
 	agent {
-		label 'ec2-java17-agent'
+		label 'docker-builder'
     }
 
     options {
@@ -24,52 +99,61 @@ pipeline {
 
         stage('Set up QEMU') {
 			steps {
-				sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || true'
-    		}
-		}
+				container('docker') {
+					sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || true'
+                }
+            }
+        }
 
         stage('Set up Docker Buildx') {
 			steps {
-				sh 'docker buildx create --use --name mybuilder || true'
-                sh 'docker buildx inspect --bootstrap'
+				container('docker') {
+					sh 'docker buildx create --use --name mybuilder || true'
+                    sh 'docker buildx inspect --bootstrap'
+                }
             }
         }
 
         stage('Login to AWS ECR Public') {
 			steps {
-				withCredentials([
-                    usernamePassword(
-                        credentialsId: 'aws-username-password',
-                        usernameVariable: 'AWS_ACCESS_KEY_ID',
-                        passwordVariable: 'AWS_SECRET_ACCESS_KEY'
-                    )
-                ]) {
-					sh '''
-                        aws ecr-public get-login-password --region $AWS_REGION \
-                        | docker login --username AWS --password-stdin public.ecr.aws
-                    '''
+				container('aws-cli') {
+					withCredentials([
+                        usernamePassword(
+                            credentialsId: 'aws-username-password',
+                            usernameVariable: 'AWS_ACCESS_KEY_ID',
+                            passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+                        )
+                    ]) {
+						sh '''
+                            aws ecr-public get-login-password --region $AWS_REGION \
+                            | docker login --username AWS --password-stdin public.ecr.aws
+                        '''
+                    }
                 }
             }
         }
 
         stage('SonarQube Analysis') {
 			steps {
-				withSonarQubeEnv('sonarqube-server') {
-					sh 'sonar-scanner -Dsonar.projectKey=sboot-order-processor -Dsonar.sources=.'
+				container('docker') {
+					withSonarQubeEnv('sonarqube-server') {
+						sh 'sonar-scanner -Dsonar.projectKey=sboot-order-processor -Dsonar.sources=.'
+                    }
                 }
             }
         }
 
         stage('Build Multi-Arch') {
 			steps {
-				sh '''
-                    docker buildx build \
-						--platform linux/amd64,linux/arm64 \
-						-t $DOCKER_IMAGE:latest \
-						--push .
-                '''
+				container('docker') {
+					sh '''
+                        docker buildx build \
+                            --platform linux/amd64,linux/arm64 \
+                            -t $DOCKER_IMAGE:latest \
+                            --push .
+                    '''
+                }
             }
         }
-
     }
 }


### PR DESCRIPTION
- replaced direct shell execution with container blocks.
- updated agent label from 'ec2-java17-agent' to 'docker-builder'.
- wrapped QEMU setup inside a 'docker' container.
- wrapped Docker Buildx step inside a 'docker' container.
- wrapped AWS ECR login inside an 'aws-cli' container.
- wrapped SonarQube and multi-arch build steps in 'docker' containers.