### PR TITLE
Replace curl with wget in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN set -eux; \
 
 ENV PATH=$JAVA_HOME/bin:$PATH
 
-RUN curl -L https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -P /tmp && \
+RUN wget --no-check-certificate -P https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip -P /tmp && \
     unzip -d /opt/gradle /tmp/gradle-${GRADLE_VERSION}-bin.zip && \
     ln -s /opt/gradle/gradle-${GRADLE_VERSION}/bin/gradle /usr/bin/gradle
 


### PR DESCRIPTION
- changed curl command to wget for downloading Gradle.
- added --no-check-certificate option to wget command.