### PR TITLE
Update AWS ECR stage name in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
             }
         }
 
-        stage('Login to AWS ECR Public') {
+        stage('Login to AWS ECR') {
 			steps {
 				container('aws-cli') {
 					withCredentials([


### PR DESCRIPTION
- renamed stage from 'Login to AWS ECR Public' to 'Login to AWS ECR'.