### PR TITLE
Adjust .dockerignore exclusions for build/libs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,8 @@ test/
 *.iml
 .idea/
 *.log
-**/build/
+**/build
+!build/libs/app.jar
 **/dist/
 **/out/
 target/*


### PR DESCRIPTION
- removed trailing slash from **/build/ to refine matching.
- added exception for build/libs/app.jar.