### PR TITLE
Update docker build command for detailed progress

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,13 +130,13 @@ pipeline {
 					]) {
 								sh '''
 
-								docker buildx build --verbose \
+								docker buildx build \
 									--platform linux/amd64,linux/arm64 \
 									--build-arg JAR_FILE=app.jar \
 									--cache-from=type=local,src=/cache/docker \
 									--cache-to=type=local,dest=/cache/docker,mode=max \
 									-t $DOCKER_IMAGE:latest \
-									--push .
+									--push --progress=plain .
 								'''
 					}
 				}


### PR DESCRIPTION
- removed `--verbose` flag from docker buildx command.
- added `--progress=plain` flag for detailed progress output.