### PR TITLE
Update Docker cache paths in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -133,10 +133,10 @@ pipeline {
 								docker buildx build \
 									--platform linux/amd64,linux/arm64 \
 									--build-arg JAR_FILE=app.jar \
-									--cache-from=type=local,src=/cache/docker \
-									--cache-to=type=local,dest=/cache/docker,mode=max \
+									--cache-from=type=local,src=/var/lib/docker/buildkit \
+									--cache-to=type=local,dest=/var/lib/docker/buildkit,mode=max \
 									-t $DOCKER_IMAGE:latest \
-									--push --progress=plain .
+									--push .
 								'''
 					}
 				}


### PR DESCRIPTION
- changed `--cache-from` path to `/var/lib/docker/buildkit`.
- updated `--cache-to` path to `/var/lib/docker/buildkit`.