### PR TITLE
Adjust Jenkinsfile build and caching sequence

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,26 +119,29 @@ pipeline {
 		stage('Build Multi-Arch') {
 			steps {
 				container('docker') {
-					writeFile file: "buildx-cache.key", text: "$GIT_COMMIT"
-                cache(caches: [
-                        arbitraryFileCache(
-                            path: '/var/lib/docker/buildkit',
-                            includes: '**/*',
-                            cacheValidityDecidingFile: 'buildx-cache.key'
-                        )
-                    ]) {
-						sh '''
-                            docker buildx build \
-                               --platform linux/amd64,linux/arm64 \
-                               --build-arg JAR_FILE=app.jar \
-                               --cache-from=type=local,src=/var/lib/docker/buildkit \
-                               --cache-to=type=local,dest=/var/lib/docker/buildkit,mode=max \
-                               -t $DOCKER_IMAGE:latest \
-                               --push .
-                        '''
-                    }
+					sh '''
+						docker buildx build \
+						   --platform linux/amd64,linux/arm64 \
+						   --build-arg JAR_FILE=app.jar \
+						   --cache-from=type=local,src=/var/lib/docker/buildkit \
+						   --cache-to=type=local,dest=/var/lib/docker/buildkit,mode=max \
+						   -t $DOCKER_IMAGE:latest \
+						   --push .
+                	'''
 
-            	}
+                	writeFile file: "buildx-cache.key", text: "$GIT_COMMIT"
+
+					cache(caches: [
+							arbitraryFileCache(
+								path: '/var/lib/docker/buildkit',
+								includes: '**/*',
+								cacheValidityDecidingFile: 'buildx-cache.key'
+							)
+						]) {
+						sh 'chmod -R 777 /var/lib/docker/buildkit'
+					}
+
+				}
         	}
     	}
 


### PR DESCRIPTION
- reordered cache setup steps in the Build Multi-Arch stage.
- added permissions adjustment with `chmod` for buildkit.
- updated `buildx-cache.key` write placement in sequence.