### PR TITLE
Simplify multi-arch build process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,38 +100,14 @@ pipeline {
 		stage('Build Multi-Arch') {
 			steps {
 				container('buildah') {
-					// Use uma chave de cache fixa, por exemplo "buildah-cache", para não invalidar o cache a cada build.
-					writeFile file: "buildah-cache.key", text: "buildah-cache"
-					cache(caches: [
-						arbitraryFileCache(
-							// Certifique-se de que o PVC está montado nesse diretório,
-							// que é onde o Buildah armazena suas camadas por padrão.
-							path: '/var/lib/containers/storage',
-							includes: '**/*',
-							cacheValidityDecidingFile: 'buildah-cache.key'
-						)
-					]) {
-								sh '''
-							buildah bud --layers --platform linux/amd64,linux/arm64 \
-								--build-arg JAR_FILE=app.jar \
-								-t $DOCKER_IMAGE:latest .
-						'''
-							}
-						}
-			}
-		}
-
-		//stage('Build Multi-Arch') {
-		//	steps {
-		//		container('buildah') {
-		//			sh '''
-		//				buildah bud --layers --platform linux/amd64,linux/arm64 \
-		//					--build-arg JAR_FILE=app.jar \
-		//					-t $DOCKER_IMAGE:latest .
-		//			'''
-        //    	}
-        //	}
-    	//}
+					sh '''
+						buildah bud --layers --platform linux/amd64,linux/arm64 \
+							--build-arg JAR_FILE=app.jar \
+							-t $DOCKER_IMAGE:latest .
+					'''
+            	}
+        	}
+    	}
 
     	stage('Push Image') {
 			steps {


### PR DESCRIPTION
- removed cache mechanism for Buildah builds.
- retained buildah bud command with multi-arch options.
- removed commented-out redundant build stage.