### PR TITLE
Update stage name for Docker Hub login

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 			}
 		}
 
-		stage('Login Docker Hub') {
+		stage('Login Buildah Docker Hub') {
 			steps {
 				container('buildah') {
 					withCredentials([usernamePassword(


### PR DESCRIPTION
- renamed stage 'Login Docker Hub' to 'Login Buildah Docker Hub'.