### PR TITLE
Correct Docker image variable usage in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
 								--build-arg JAR_FILE=app.jar \
 								--cache-from=type=local,src=docker_storage_cache \
 								--cache-to=type=local,dest=docker_storage_cache,mode=max \
-								-t $DOCKER_IMAGE:latest \
+								-t ${DOCKER_IMAGE}:latest \
 								--push .
 						'''
 


### PR DESCRIPTION
- replaced `$DOCKER_IMAGE` with `${DOCKER_IMAGE}` for consistency.