### PR TITLE
Switch from Docker to Buildah for CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,23 +42,6 @@ pipeline {
             }
         }
 
-        stage('Set up QEMU') {
-			steps {
-				container('docker') {
-					sh 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes || true'
-                }
-            }
-        }
-
-        stage('Set up Docker Buildx') {
-			steps {
-				container('docker') {
-					sh 'docker buildx create --use --name mybuilder || true'
-                    sh 'docker buildx inspect --bootstrap'
-                }
-            }
-        }
-
         stage('Login AWS CLI ECR') {
 			steps {
 				container('aws-cli') {
@@ -77,39 +60,29 @@ pipeline {
 			}
 		}
 
-		stage('Login to Docker') {
+		stage('Login Buildah AWS ECR') {
 			steps {
-				container('docker') {
+				container('buildah') {
 					sh '''
-						cat ecr-login.txt | docker login --username AWS --password-stdin public.ecr.aws
+						buildah login -u AWS -p $(cat ecr-login.txt) public.ecr.aws
 					'''
 				}
 			}
 		}
 
-		//stage('Login Buildah AWS ECR') {
-		//	steps {
-		//		container('buildah') {
-		//			sh '''
-		//				buildah login -u AWS -p $(cat ecr-login.txt) public.ecr.aws
-		//			'''
-		//		}
-		//	}
-		//}
-
-		//stage('Login Buildah Docker Hub') {
-		//	steps {
-		//		container('buildah') {
-		//			withCredentials([usernamePassword(
-		//				credentialsId: 'docker-hub-credentials',
-		//				usernameVariable: 'DOCKERHUB_USER',
-		//				passwordVariable: 'DOCKERHUB_PASS'
-		//			)]) {
-		//				sh 'buildah login -u $DOCKERHUB_USER -p $DOCKERHUB_PASS docker.io'
-		//			}
-		//		}
-		//	}
-		//}
+		stage('Login Buildah Docker Hub') {
+			steps {
+				container('buildah') {
+					withCredentials([usernamePassword(
+						credentialsId: 'docker-hub-credentials',
+						usernameVariable: 'DOCKERHUB_USER',
+						passwordVariable: 'DOCKERHUB_PASS'
+					)]) {
+						sh 'buildah login -u $DOCKERHUB_USER -p $DOCKERHUB_PASS docker.io'
+					}
+				}
+			}
+		}
 
     	stage('SonarQube Analysis') {
 			steps {
@@ -140,38 +113,29 @@ pipeline {
 
 		stage('Build Multi-Arch') {
 			steps {
-				container('docker') {
-					writeFile file: "docker-cache.key", text: "$GIT_COMMIT"
+				container('buildah') {
+					writeFile file: "buildah-cache.key", text: "$GIT_COMMIT"
 
 					sh'''
-						mkdir -p docker_storage_cache
-						chmod -R 777 docker_storage_cache
+						mkdir -p buildah_storage_cache
+						chmod -R 777 buildah_storage_cache
 					'''
 
 					cache(caches: [
 						arbitraryFileCache(
-							path: 'docker_storage_cache',
+							path: 'buildah_storage_cache',
 							includes: '**/*',
-							cacheValidityDecidingFile: 'docker-cache.key'
+							cacheValidityDecidingFile: 'buildah-cache.key'
 						)
 					]) {
-
-						sh'''
-							cp -r docker_storage_cache /var/lib/docker/buildkit
-						'''
-
 						sh '''
-							docker buildx build \
-								--platform linux/amd64,linux/arm64 \
-								--build-arg JAR_FILE=app.jar \
-								--cache-from=type=local,src=docker_storage_cache \
-								--cache-to=type=local,dest=docker_storage_cache,mode=max \
-								-t $APP_IMAGE:latest \
-								--push .
-						'''
+							cp -r buildah_storage_cache /var/lib/containers/storage
 
-						sh'''
-							cp -r /var/lib/docker/buildkit docker_storage_cache
+							buildah bud --layers --platform linux/amd64 -t ${APP_IMAGE}-amd64:latest .
+							buildah bud --layers --platform linux/arm64 -t ${APP_IMAGE}-arm64:latest .
+							buildah manifest create ${APP_IMAGE}:latest --amend ${APP_IMAGE}-amd64:latest --amend ${APP_IMAGE}-arm64:latest
+
+							cp -r /var/lib/containers/storage buildah_storage_cache
 						'''
 
 					}
@@ -179,15 +143,15 @@ pipeline {
 			}
 		}
 
-		//stage('Push Image') {
-		//	steps {
-		//		container('buildah') {
-		//			sh '''
-        //        		buildah manifest push ${APP_IMAGE}:latest docker://${APP_IMAGE}:latest
-        //    		'''
-		//		}
-		//	}
-		//}
+		stage('Push Image') {
+			steps {
+				container('buildah') {
+					sh '''
+                		buildah manifest push ${APP_IMAGE}:latest docker://${APP_IMAGE}:latest
+            		'''
+				}
+			}
+		}
 
 	}
 }


### PR DESCRIPTION
- removed QEMU and Docker Buildx setup stages.
- replaced Docker login with Buildah login for AWS ECR.
- re-enabled Buildah login for Docker Hub.
- updated multi-arch build stage to use Buildah.
- added manifest push using Buildah in the push image stage.