### PR TITLE
Correct Docker image source URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-slim
+FROM ocker.io/library/openjdk:21-slim
 
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} /app/app.jar


### PR DESCRIPTION
- updated base image URL to use `docker.io/library/openjdk:21-slim`.