### PR TITLE
fix: correct Docker image source URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocker.io/library/openjdk:21-slim
+FROM docker.io/library/openjdk:21-slim
 
 ARG JAR_FILE=build/libs/app.jar
 COPY ${JAR_FILE} /app/app.jar


### PR DESCRIPTION
- fixed typo in Docker image source URL (`ocker.io` to `docker.io`).